### PR TITLE
Fix spacing in quick start guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -1190,7 +1190,7 @@ for _ in range(1000):
         </div>
       </div>
 
-      <div class="card">
+      <div class="card" style="margin-top: 32px;">
         <h3>🤖 Agent Training Pipeline</h3>
         <p class="muted">Complete PPO training setup for baseline agent development and reward function evaluation.</p>
         <pre class="line-numbers"><code class="language-python">from space_mining.agents.train_ppo import train_ppo
@@ -1212,7 +1212,7 @@ if __name__ == "__main__":
     main()</code></pre>
       </div>
 
-      <div class="card">
+      <div class="card" style="margin-top: 32px;">
         <h3>🎬 Generate Demo GIFs</h3>
         <p class="muted">Create demonstration GIFs from trained models for research analysis.</p>
         <pre class="line-numbers"><code class="language-bash"># Train PPO Agent
@@ -1226,7 +1226,7 @@ python -m space_mining.scripts.make_gif \
           demonstrations for research documentation.</p>
       </div>
 
-      <div class="card">
+      <div class="card" style="margin-top: 32px;">
         <h3>🔧 Research Configuration</h3>
         <p class="muted">Environment parameter customization for controlled experiments and ablation studies.</p>
         <pre class="line-numbers"><code class="language-python">from space_mining.envs import SpaceMining, EnvironmentConfig


### PR DESCRIPTION
Add consistent vertical spacing to cards in the Quick Start Guide section.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7eb2e8e-3004-40af-bb33-4e51e04f07a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7eb2e8e-3004-40af-bb33-4e51e04f07a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

