### PR TITLE
Fix gif generation script and documentation

### DIFF
--- a/examples/04_load_from_hf_and_render.py
+++ b/examples/04_load_from_hf_and_render.py
@@ -22,7 +22,8 @@ def main() -> None:
 
     obs, _ = env.reset()
     for _ in range(600):
-        action, _ = agent.predict(obs, deterministic=True)
+        prediction = agent.predict(obs, deterministic=True)
+        action = prediction[0] if isinstance(prediction, (tuple, list)) else prediction
         obs, _, terminated, truncated, _ = env.step(action)
         env.render()
         if terminated or truncated:

--- a/hf_model_card_template.md
+++ b/hf_model_card_template.md
@@ -22,7 +22,9 @@ model = PPO.load(ckpt_path)
 env = make_env(render_mode='rgb_array')
 obs, _ = env.reset()
 for _ in range(300):
-    action, _ = model.predict(obs, deterministic=True)
+    # SB3 `predict` may return `(action, state, *extras)` depending on version.
+    prediction = model.predict(obs, deterministic=True)
+    action = prediction[0] if isinstance(prediction, (tuple, list)) else prediction
     obs, reward, terminated, truncated, info = env.step(action)
     if terminated or truncated:
         break

--- a/space_mining/agents/train_ppo.py
+++ b/space_mining/agents/train_ppo.py
@@ -250,7 +250,8 @@ def evaluate_trained_ppo(
             total_reward = 0.0
             
             while not (done or truncated):
-                action, _ = agent.predict(obs, deterministic=True)
+                prediction = agent.predict(obs, deterministic=True)
+                action = prediction[0] if isinstance(prediction, (tuple, list)) else prediction
                 obs, reward, done, truncated, _info = env.step(action)
                 total_reward += float(reward)
                 

--- a/space_mining/scripts/make_gif.py
+++ b/space_mining/scripts/make_gif.py
@@ -65,7 +65,11 @@ def generate_trajectory(
     frames: List[Union[np.ndarray, Image.Image]] = [env.render()]
 
     for _ in range(num_steps):
-        action, _ = agent.predict(obs, deterministic=deterministic)
+        prediction = agent.predict(obs, deterministic=deterministic)
+        # The Stable-Baselines3 API may return either a tuple (action, state, ...)
+        # or a single ndarray depending on version and kwargs.  Extract the first
+        # element if a sequence is returned so we remain version-agnostic.
+        action = prediction[0] if isinstance(prediction, (tuple, list)) else prediction
         obs, _, terminated, truncated, _ = env.step(action)
         frames.append(env.render())
         if terminated or truncated:

--- a/space_mining/scripts/render_episode.py
+++ b/space_mining/scripts/render_episode.py
@@ -22,7 +22,8 @@ def render_episode(model_path: str, max_steps: int = 1000, device: str = "cpu") 
     obs, _ = env.reset()
 
     for step_idx in range(max_steps):
-        action, _ = agent.predict(obs, deterministic=True)
+        prediction = agent.predict(obs, deterministic=True)
+        action = prediction[0] if isinstance(prediction, (tuple, list)) else prediction
         obs, _, terminated, truncated, _ = env.step(action)
         env.render()
         if terminated or truncated:


### PR DESCRIPTION
Make `agent.predict` unpacking robust to prevent `ValueError: too many values to unpack`.

The `agent.predict` method from Stable-Baselines3 can return a varying number of values (e.g., `action` or `(action, state, ...)`) depending on the SB3 version or specific model configuration. This PR updates all relevant calls to safely extract the action, preventing `ValueError` when the returned value is not a tuple of exactly two elements. This specifically fixes the `make_gif.py` script and ensures broader compatibility across other scripts and documentation examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8fe8b78-d358-4252-a0cd-14fafaac46c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8fe8b78-d358-4252-a0cd-14fafaac46c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

